### PR TITLE
Fix container detection; sign text

### DIFF
--- a/src/main/java/org/gestern/gringotts/event/AccountListener.java
+++ b/src/main/java/org/gestern/gringotts/event/AccountListener.java
@@ -49,10 +49,10 @@ public class AccountListener implements Listener {
             // allow either the block sign is attached to or the block below the sign as chest block. Prefer attached block.
             Block blockAttached = signBlock.getRelative(attached);
             Block blockBelow = signBlock.getRelative(BlockFace.DOWN);
-            if (! AccountChest.validContainer(blockAttached.getType()) ||
+            if (! AccountChest.validContainer(blockAttached.getType()) &&
             	! AccountChest.validContainer(blockBelow.getType()))
             	return; // no valid container, ignore
-            
+                        
             // we made it this far, throw the event to manage vault creation
         	VaultCreationEvent creation = new PlayerVaultCreationEvent(type, event);
         	Bukkit.getServer().getPluginManager().callEvent(creation);

--- a/src/main/java/org/gestern/gringotts/event/VaultCreator.java
+++ b/src/main/java/org/gestern/gringotts/event/VaultCreator.java
@@ -38,7 +38,7 @@ public class VaultCreator implements Listener {
         if (accounting.addChest(account, accountChest)) {
         	// only embolden if the bold marker doesn't increase line length beyond 15
         	if (cause.getLine(0).length() <= 13)
-        		cause.setLine(0, ChatColor.BOLD + "["+ event.getType() +" vault]");
+        		cause.setLine(0, ChatColor.BOLD + cause.getLine(0));
         	cause.setLine(2, owner.getName());
             cause.getPlayer().sendMessage("Created a vault for your account.");
 


### PR DESCRIPTION
- Containers probably won't ever be below themselves. (Minecraft 1.6:
  The Quantum Update?)
- event.getType() returns "player" for normal vaults, pushing line
  length over 15 char; reverted to cause.getline(0)
