### PR TITLE
Exclude transitive WG deps (i.e. Bukkit 0.0.1 and Spout)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>minecraftwars</groupId>
     <artifactId>Gringotts</artifactId>
-    <version>2.0-beta5</version>
+    <version>2.1</version>
 
     <build>
         <resources>
@@ -95,13 +95,6 @@
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
             <version>1.6.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>massivecraft</groupId>
-            <artifactId>factions</artifactId>
-            <version>1.8.0</version>
-            <optional>true</optional>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/gestern/gringotts/dependency/Dependency.java
+++ b/src/main/java/org/gestern/gringotts/dependency/Dependency.java
@@ -9,7 +9,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.gestern.gringotts.Gringotts;
 
-import com.massivecraft.factions.P;
+import com.massivecraft.factions.Factions;
 import com.palmergames.bukkit.towny.Towny;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 
@@ -39,7 +39,7 @@ public enum Dependency {
      * but the classes must be visible to the classloader. 
      */
     private Dependency() {
-        factions = new FactionsHandler((P)hookPlugin("Factions", "com.massivecraft.factions.P","1.6.9.1"));
+        factions = new FactionsHandler((Factions)hookPlugin("Factions", "com.massivecraft.factions.Factions","2.1.0"));
         towny = TownyHandler.getTownyHandler((Towny)hookPlugin("Towny","com.palmergames.bukkit.towny.Towny","0.82.0.0"));
         vault = new GenericHandler((Vault)hookPlugin("Vault","net.milkbowl.vault.Vault","1.2.24"));
         worldguard = new WorldGuardHandler((WorldGuardPlugin)hookPlugin("WorldGuard", "com.sk89q.worldguard.bukkit.WorldGuardPlugin", "5.7"));

--- a/src/main/java/org/gestern/gringotts/dependency/FactionsHandler.java
+++ b/src/main/java/org/gestern/gringotts/dependency/FactionsHandler.java
@@ -14,17 +14,16 @@ import org.gestern.gringotts.accountholder.AccountHolder;
 import org.gestern.gringotts.accountholder.AccountHolderProvider;
 import org.gestern.gringotts.event.PlayerVaultCreationEvent;
 
-import com.massivecraft.factions.FPlayer;
-import com.massivecraft.factions.FPlayers;
-import com.massivecraft.factions.Faction;
+import com.massivecraft.factions.entity.UPlayer;
+import com.massivecraft.factions.entity.Faction;
+import com.massivecraft.factions.entity.FactionColls;
 import com.massivecraft.factions.Factions;
-import com.massivecraft.factions.P;
 
 public class FactionsHandler implements DependencyHandler, AccountHolderProvider {
 
-    private final P plugin;
+    private final Factions plugin;
 
-    public FactionsHandler(P plugin) {
+    public FactionsHandler(Factions plugin) {
         this.plugin = plugin;
 
         if (plugin != null) {
@@ -40,7 +39,7 @@ public class FactionsHandler implements DependencyHandler, AccountHolderProvider
      */
     public FactionAccountHolder getFactionAccountHolder(Player player) {
 
-        FPlayer fplayer = FPlayers.i.get(player);
+        UPlayer fplayer = UPlayer.get(player);
         Faction playerFaction = fplayer.getFaction();
         return playerFaction != null? new FactionAccountHolder(playerFaction) : null;
     }
@@ -51,7 +50,7 @@ public class FactionsHandler implements DependencyHandler, AccountHolderProvider
      * @return
      */
     public FactionAccountHolder getAccountHolderById(String id) {
-        Faction faction = Factions.i.get(id);
+        Faction faction = FactionColls.get().get2(id);
         return faction !=null? new FactionAccountHolder(faction) : null;
     }
 
@@ -86,7 +85,7 @@ public class FactionsHandler implements DependencyHandler, AccountHolderProvider
         if (owner != null) return owner;
 
         // just in case, also try the tag
-        Faction faction = Factions.i.getByTag(id);
+        Faction faction = FactionColls.get().get2(id);;
 
         if (faction != null) 
             return new FactionAccountHolder(faction);
@@ -142,8 +141,8 @@ class FactionAccountHolder implements AccountHolder {
         this.owner = owner;
     }
 
-    public FactionAccountHolder(String Id) {
-        Faction faction = Factions.i.get(Id);
+    public FactionAccountHolder(String id) {
+        Faction faction = FactionColls.get().get2(id);
 
         if (faction != null)
             this.owner = faction;
@@ -152,7 +151,7 @@ class FactionAccountHolder implements AccountHolder {
 
     @Override
     public String getName() {
-        return owner.getTag();
+        return owner.getName();
     }
 
     @Override


### PR DESCRIPTION
Little hack to avoid pulling transitives from improperly configured deps. Works with warnings through Maven 3.0.5+.
