### PR TITLE
Add support for named denominations.

### DIFF
--- a/src/main/java/org/gestern/gringotts/api/impl/GringottsEco.java
+++ b/src/main/java/org/gestern/gringotts/api/impl/GringottsEco.java
@@ -313,7 +313,7 @@ public class GringottsEco implements Eco {
 
         Curr(GringottsCurrency curr) {
             this.gcurr = curr;
-            formatString = "%."+curr.digits+"f %s";
+            formatString = "%."+curr.digits+"f";
         }
 
         @Override
@@ -328,7 +328,7 @@ public class GringottsEco implements Eco {
 
         @Override
         public String format(double value) {
-            return String.format(formatString, value, value==1.0? gcurr.name : gcurr.namePlural);
+            return gcurr.format(formatString, value);
         }
 
         @Override

--- a/src/main/java/org/gestern/gringotts/currency/Denomination.java
+++ b/src/main/java/org/gestern/gringotts/currency/Denomination.java
@@ -19,6 +19,8 @@ public class Denomination implements Comparable<Denomination> {
     public final int id;
     public final short damage;
     public final long value;
+    public String name;
+    public String namePlural;
 
     public Denomination(ItemStack type) {
         this(type, 0);
@@ -64,7 +66,11 @@ public class Denomination implements Comparable<Denomination> {
 
     @Override
     public String toString() {
-        return String.format("Denomination: %d;%d : %d", id, damage, value);
+        return String.format("Denomination: (%s) %d;%d : %d", (name == null ? "" : name), id, damage, value);
     }
 
+    public boolean hasName() {
+        return this.namePlural != null && this.namePlural.length() > 0
+                && this.name != null && this.name.length() > 0;
+    }
 }


### PR DESCRIPTION
This PR adds support for configurable named denominations, such as can be seen in this example config:

https://github.com/elBukkit/MagicPlugin/blob/master/src/main/resources/examples/potter/Gringotts/config.yml#L15

The configuration is backwards compatible (I've left the default alone) and supports a mixture of simple and complex denomination configurations.

The list can also contain a mix of named and unnamed denominations, as seen here:

![PotterGringotts](https://lh4.googleusercontent.com/-EOuXN4WWJKI/U5c9prIICAI/AAAAAAAAAbU/WRwE-xGuRL8/w714-h171-no/GringottsHP.png)

The "galleons" (emeralds) stored in the emerald blocks still count, though they are not displayed as blocks. The lowest denomination will still use the formatting string to output the remainder, and will be used for a 0 balance (meaning the lowest denomination should probably be named!)

I've also tested this with the default config and it still works as expected.