### PR TITLE
Fix Factions 2.7.5 integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>minecraftwars</groupId>
     <artifactId>Gringotts</artifactId>
-    <version>2.4-SNAPSHOT</version>
+    <version>2.5-SNAPSHOT</version>
 
     <build>
         <resources>
@@ -109,18 +109,6 @@
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.4</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.massivecraft</groupId>
-            <artifactId>mcore</artifactId>
-            <version>7.1.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.massivecraft</groupId>
-            <artifactId>factions</artifactId>
-            <version>2.3.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/gestern/gringotts/dependency/FactionsHandler.java
+++ b/src/main/java/org/gestern/gringotts/dependency/FactionsHandler.java
@@ -2,8 +2,8 @@ package org.gestern.gringotts.dependency;
 
 import com.massivecraft.factions.Factions;
 import com.massivecraft.factions.entity.Faction;
-import com.massivecraft.factions.entity.FactionColls;
-import com.massivecraft.factions.entity.UPlayer;
+import com.massivecraft.factions.entity.FactionColl;
+import com.massivecraft.factions.entity.MPlayer;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -38,7 +38,7 @@ public class FactionsHandler implements DependencyHandler, AccountHolderProvider
      */
     public FactionAccountHolder getFactionAccountHolder(Player player) {
 
-        UPlayer fplayer = UPlayer.get(player);
+        MPlayer fplayer = MPlayer.get(player);
         Faction playerFaction = fplayer.getFaction();
         return playerFaction != null? new FactionAccountHolder(playerFaction) : null;
     }
@@ -49,7 +49,7 @@ public class FactionsHandler implements DependencyHandler, AccountHolderProvider
      * @return faction account holder for given id
      */
     public FactionAccountHolder getAccountHolderById(String id) {
-        Faction faction = FactionColls.get().get2(id);
+        Faction faction = FactionColl.get().get(id);
         return faction != null? new FactionAccountHolder(faction) : null;
     }
 
@@ -84,7 +84,7 @@ public class FactionsHandler implements DependencyHandler, AccountHolderProvider
         if (owner != null) return owner;
 
         // just in case, also try the tag
-        Faction faction = FactionColls.get().get2(id);
+        Faction faction = FactionColl.get().get(id);
 
         if (faction != null) 
             return new FactionAccountHolder(faction);
@@ -141,7 +141,7 @@ class FactionAccountHolder implements AccountHolder {
     }
 
     public FactionAccountHolder(String id) {
-        Faction faction = FactionColls.get().get2(id);
+        Faction faction = FactionColl.get().get(id);
 
         if (faction != null)
             this.owner = faction;


### PR DESCRIPTION
Gringott's Factions integration is broken for the latest 2.7.5 version.
I made this workaround and it runs in **Spigot 1.8-R0.1** with **Factions 2.7.5**

The main problem is that Factions stopped using Maven from this commit: https://github.com/MassiveCraft/Factions/commit/c81d7d8794d80846cfc8d11cfe1df98367c868d5
I know it sucks because now you have to manually import the Factions jar. I'm pretty noob with Maven, but I think there's no other way.

Feel free to modify this as you wish