### PR TITLE
Removed Metrics Lite for Spigot 1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <version>1.9-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -99,11 +99,6 @@
             <version>0.89.2.0</version>
             <scope>provided</scope>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.mcstats.bukkit</groupId>
-            <artifactId>metrics-lite</artifactId>
-            <version>R7</version>
         </dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
@@ -168,6 +163,10 @@
         <url>https://github.com/MinecraftWars/Gringotts/issues</url>
     </issueManagement>
     <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
         <repository>
             <id>znode</id>
             <url>http://repo.zno.de/artifactory/repo/</url>

--- a/src/main/java/org/gestern/gringotts/Gringotts.java
+++ b/src/main/java/org/gestern/gringotts/Gringotts.java
@@ -20,7 +20,6 @@ import org.gestern.gringotts.data.Migration;
 import org.gestern.gringotts.event.AccountListener;
 import org.gestern.gringotts.event.PlayerVaultListener;
 import org.gestern.gringotts.event.VaultCreator;
-import org.mcstats.MetricsLite;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -74,13 +73,6 @@ public class Gringotts extends JavaPlugin {
             registerCommands();
             registerEvents();
             registerEconomy();
-
-            try {
-                MetricsLite metrics = new MetricsLite(this);
-                metrics.start();
-            } catch (IOException err) {
-                log.log(Level.INFO, "Failed to submit PluginMetrics stats", err);
-            }
 
         } catch(GringottsStorageException | GringottsConfigurationException e) {
             log.severe(e.getMessage()); 


### PR DESCRIPTION
Metrics Lite is not compatible with the change made to getOnlinePlayers(), so I thought of removing it completly.
Who uses Metrics Lite nowadays.