### PR TITLE
Code quality fix - Strings literals should be placed on the left side when checking for equality.

### DIFF
--- a/src/main/java/org/gestern/gringotts/Commands.java
+++ b/src/main/java/org/gestern/gringotts/Commands.java
@@ -61,17 +61,17 @@ class Commands {
                 try { value = Double.parseDouble(args[1]); } 
                 catch (NumberFormatException ignored) { return false; }
 
-                if (command.equals("withdraw")) {
+                if ("withdraw".equals(command)) {
                     withdraw(player, value);
                     return true;
-                } else if (command.equals("deposit")) {
+                } else if ("deposit".equals(command)) {
                     deposit(player, value);
                     return true;
                 }
             } 
 
             // money pay <amount> <player>
-            if(args.length == 3 && command.equals("pay")) {                
+            if(args.length == 3 && "pay".equals(command)) {
                 return pay(player, value, args);
             }
 
@@ -173,7 +173,7 @@ class Commands {
             } else return false;
 
             // admin command: x of player / faction
-            if (args.length >= 2 && command.equalsIgnoreCase("b"))  {
+            if (args.length >= 2 && "b".equalsIgnoreCase(command))  {
 
                 String targetAccountHolderStr = args[1];
 
@@ -208,7 +208,7 @@ class Commands {
 
                 String formatValue = eco.currency().format(value);
 
-                if (command.equalsIgnoreCase("add")) {
+                if ("add".equalsIgnoreCase(command)) {
                     TransactionResult added = target.add(value);
                     if (added == SUCCESS) {
                         String senderMessage = LANG.moneyadmin_add_sender.replace("%value", formatValue).replace("%player", target.id());
@@ -222,7 +222,7 @@ class Commands {
 
                     return true;
 
-                } else if (command.equalsIgnoreCase("rm")) {
+                } else if ("rm".equalsIgnoreCase(command)) {
                     TransactionResult removed = target.remove(value); 
                     if (removed == SUCCESS) {
                         String senderMessage = LANG.moneyadmin_rm_sender.replace("%value", formatValue).replace("%player", target.id());

--- a/src/main/java/org/gestern/gringotts/dependency/FactionsHandler.java
+++ b/src/main/java/org/gestern/gringotts/dependency/FactionsHandler.java
@@ -152,7 +152,7 @@ class FactionsListener implements Listener {
         // some listener already claimed this event
         if (event.isValid()) return;
 
-        if (event.getType().equals("faction")) {
+        if ("faction".equals(event.getType())) {
             Player player = event.getCause().getPlayer();
             if (!CREATEVAULT_FACTION.allowed(player)) {
                 player.sendMessage(LANG.plugin_faction_noVaultPerm);

--- a/src/main/java/org/gestern/gringotts/dependency/TownyHandler.java
+++ b/src/main/java/org/gestern/gringotts/dependency/TownyHandler.java
@@ -168,7 +168,7 @@ class TownyListener implements Listener {
         boolean forOther = ownername!=null && ownername.length()>0 && CREATEVAULT_ADMIN.allowed(player);
 
         AccountHolder owner;
-        if (event.getType().equals("town")) {
+        if ("town".equals(event.getType())) {
             if (!CREATEVAULT_TOWN.allowed(player)) {
                 player.sendMessage(LANG.plugin_towny_noTownVaultPerm);
                 return;
@@ -189,7 +189,7 @@ class TownyListener implements Listener {
             event.setOwner(owner);
             event.setValid(true);
 
-        } else if (event.getType().equals("nation")) {
+        } else if ("nation".equals(event.getType())) {
             if (!CREATEVAULT_NATION.allowed(player)) {
                 player.sendMessage(LANG.plugin_towny_noNationVaultPerm);
                 return;

--- a/src/main/java/org/gestern/gringotts/dependency/WorldGuardHandler.java
+++ b/src/main/java/org/gestern/gringotts/dependency/WorldGuardHandler.java
@@ -93,7 +93,7 @@ public class WorldGuardHandler implements DependencyHandler, AccountHolderProvid
             // some listener already claimed this event
             if (event.isValid()) return;
 
-            if (event.getType().equals("region")) {
+            if ("region".equals(event.getType())) {
                 Player player = event.getCause().getPlayer();
                 if (!CREATEVAULT_WORLDGUARD.allowed(player)) {
                     player.sendMessage(LANG.plugin_faction_noVaultPerm);

--- a/src/main/java/org/gestern/gringotts/event/PlayerVaultListener.java
+++ b/src/main/java/org/gestern/gringotts/event/PlayerVaultListener.java
@@ -26,7 +26,7 @@ public class PlayerVaultListener implements Listener {
         if (event.isValid()) return;
 
         // only interested in player vaults
-        if (! event.getType().equals("player")) return;
+        if (!"player".equals(event.getType())) return;
 
         SignChangeEvent cause = event.getCause();
         String ownername = cause.getLine(2);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Faisal Hameed