### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/src/main/java/org/gestern/gringotts/api/impl/GringottsTaxedTransaction.java
+++ b/src/main/java/org/gestern/gringotts/api/impl/GringottsTaxedTransaction.java
@@ -12,6 +12,16 @@ public class GringottsTaxedTransaction extends GringottsTransaction implements T
      * Taxes to apply to transaction.
      */
     private final double taxes;
+    
+    /**
+     * Create taxed transaction, adding given amount of taxes to the given base transaction
+     * @param base transaction on which the tax is based
+     * @param taxes taxes to apply to transaction
+     */
+    protected GringottsTaxedTransaction(GringottsTransaction base, double taxes) {
+        super(base);
+        this.taxes = taxes;
+    }
 
     @Override
     public TransactionResult to(Account recipient) {
@@ -22,16 +32,6 @@ public class GringottsTaxedTransaction extends GringottsTransaction implements T
         // undo taxing if transaction failed
         if (result != SUCCESS) from.add(taxes);
         return result; 
-    }
-
-    /**
-     * Create taxed transaction, adding given amount of taxes to the given base transaction
-     * @param base transaction on which the tax is based
-     * @param taxes taxes to apply to transaction
-     */
-    protected GringottsTaxedTransaction(GringottsTransaction base, double taxes) {
-        super(base);
-        this.taxes = taxes;
     }
 
     @Override

--- a/src/main/java/org/gestern/gringotts/data/EBeanAccount.java
+++ b/src/main/java/org/gestern/gringotts/data/EBeanAccount.java
@@ -11,6 +11,18 @@ import javax.persistence.UniqueConstraint;
 @Table(name="gringotts_account")
 @UniqueConstraint(columnNames={"type","owner"})
 public class EBeanAccount {
+    
+    @Id int id;
+
+    /** Type string. */
+    @NotNull String type;
+
+    /** Owner id. */
+    @NotNull String owner;
+
+    /** Virtual balance. */
+    @NotNull long cents;
+    
     public int getId() {
         return id;
     }
@@ -42,17 +54,6 @@ public class EBeanAccount {
     public void setCents(long cents) {
         this.cents = cents;
     }
-
-    @Id int id;
-
-    /** Type string. */
-    @NotNull String type;
-
-    /** Owner id. */
-    @NotNull String owner;
-
-    /** Virtual balance. */
-    @NotNull long cents;
     
     @Override
     public String toString() {

--- a/src/main/java/org/gestern/gringotts/data/EBeanAccountChest.java
+++ b/src/main/java/org/gestern/gringotts/data/EBeanAccountChest.java
@@ -12,6 +12,16 @@ import javax.persistence.UniqueConstraint;
 @UniqueConstraint(columnNames={"world","x","y","z"})
 public class EBeanAccountChest {
 
+    @Id int id;
+
+    @NotNull String world;
+
+    @NotNull int x;
+    @NotNull int y;
+    @NotNull int z;
+
+    @NotNull int account;
+    
     public int getId() {
         return id;
     }
@@ -60,16 +70,6 @@ public class EBeanAccountChest {
         this.account = account;
     }
 
-    @Id int id;
-
-    @NotNull String world;
-
-    @NotNull int x;
-    @NotNull int y;
-    @NotNull int z;
-
-    @NotNull int account;
-    
     @Override
     public String toString() {
         return "EBeanAccountChest("+account+","+world+": "+x+","+y+","+z+")"; 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed