### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/org/gestern/gringotts/Util.java
+++ b/src/main/java/org/gestern/gringotts/Util.java
@@ -8,6 +8,8 @@ import org.bukkit.block.Sign;
 import org.gestern.gringotts.currency.GringottsCurrency;
 
 public class Util {
+    
+    private Util() {}
 
     /**
      * Check whether a block is a sign or wall sign type.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed