### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/src/main/java/org/gestern/gringotts/Commands.java
+++ b/src/main/java/org/gestern/gringotts/Commands.java
@@ -114,21 +114,21 @@ class Commands {
         
         switch (result) {
         case SUCCESS:
-            String succ_taxMessage = LANG.pay_success_tax.replace(TAG_VALUE, formattedTax);
-            String succ_sentMessage = LANG.pay_success_sender.replace(TAG_VALUE, formattedValue).replace(TAG_PLAYER, recipientName);
-            from.message(succ_sentMessage + (tax>0? succ_taxMessage : ""));
-            String succ_receivedMessage = LANG.pay_success_target.replace(TAG_VALUE, formattedValue).replace(TAG_PLAYER, player.getName());
-            to.message(succ_receivedMessage);
+            String succTaxMessage = LANG.pay_success_tax.replace(TAG_VALUE, formattedTax);
+            String succSentMessage = LANG.pay_success_sender.replace(TAG_VALUE, formattedValue).replace(TAG_PLAYER, recipientName);
+            from.message(succSentMessage + (tax>0? succTaxMessage : ""));
+            String succReceivedMessage = LANG.pay_success_target.replace(TAG_VALUE, formattedValue).replace(TAG_PLAYER, player.getName());
+            to.message(succReceivedMessage);
             return true;
         case INSUFFICIENT_FUNDS:
-            String insF_Message = LANG.pay_insufficientFunds.replace(TAG_BALANCE, formattedBalance).replace(TAG_VALUE, formattedValuePlusTax);
-            from.message(insF_Message);
+            String insFMessage = LANG.pay_insufficientFunds.replace(TAG_BALANCE, formattedBalance).replace(TAG_VALUE, formattedValuePlusTax);
+            from.message(insFMessage);
             return true;
         case INSUFFICIENT_SPACE:
-            String insS_sentMessage = LANG.pay_insS_sender.replace(TAG_PLAYER, recipientName).replace(TAG_VALUE, formattedValue);
-            from.message(insS_sentMessage);
-            String insS_receiveMessage = LANG.pay_insS_target.replace(TAG_PLAYER, from.id()).replace(TAG_VALUE, formattedValue);
-            to.message(insS_receiveMessage);
+            String insSSentMessage = LANG.pay_insS_sender.replace(TAG_PLAYER, recipientName).replace(TAG_VALUE, formattedValue);
+            from.message(insSSentMessage);
+            String insSReceiveMessage = LANG.pay_insS_target.replace(TAG_PLAYER, from.id()).replace(TAG_VALUE, formattedValue);
+            to.message(insSReceiveMessage);
             return true;
         default:
             String error = LANG.pay_error.replace(TAG_VALUE, formattedValue).replace(TAG_PLAYER, recipientName);

--- a/src/main/java/org/gestern/gringotts/Configuration.java
+++ b/src/main/java/org/gestern/gringotts/Configuration.java
@@ -41,17 +41,17 @@ public enum Configuration {
     public GringottsCurrency currency;
 
     /** Flat tax on every player-to-player transaction. This is a value in currency units. */
-    public double transactionTaxFlat = 0;
+    public double transactionTaxFlat;
 
     /** Rate tax on every player-to-player transaction. This is a fraction, e.g. 0.1 means 10% tax. */ 
-    public double transactionTaxRate = 0;
+    public double transactionTaxRate;
 
     /** Amount of non-physical money to give to new players */
     // An alternative to flooding new players' inventories with currency items
-    public long startBalancePlayer = 0;
-    public long startBalanceFaction = 0;
-    public long startBalanceTown = 0;
-    public long startBalanceNation = 0;
+    public long startBalancePlayer;
+    public long startBalanceFaction;
+    public long startBalanceTown;
+    public long startBalanceNation;
 
     /** Use container vaults (chest, dispenser, furnace). */
     public boolean usevaultContainer = true;

--- a/src/main/java/org/gestern/gringotts/event/VaultCreationEvent.java
+++ b/src/main/java/org/gestern/gringotts/event/VaultCreationEvent.java
@@ -21,7 +21,7 @@ public class VaultCreationEvent extends Event {
     protected static final HandlerList handlers = new HandlerList();
 
     private final String type;
-    private boolean isValid = false;
+    private boolean isValid;
     private AccountHolder owner;
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
pmd:RedundantFieldInitializer - Redundant Field Initializer.
squid:S00117- Local variable and method parameter names should comply with a naming convention.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/pmd:RedundantFieldInitializer
https://dev.eclipse.org/sonar/rules/show/squid:S00117 

Please let me know if you have any questions.

Faisal Hameed