### PR TITLE
Multiple code quality fix-2

### DIFF
--- a/src/main/java/org/gestern/gringotts/currency/GringottsCurrency.java
+++ b/src/main/java/org/gestern/gringotts/currency/GringottsCurrency.java
@@ -65,7 +65,7 @@ public class GringottsCurrency {
      */
     public void addDenomination(ItemStack type, double value, String unitName, String unitNamePlural) {
         DenominationKey k = new DenominationKey(type);
-        Denomination d = new Denomination(k, Math.round(centValue(value)), unitName, unitNamePlural);
+        Denomination d = new Denomination(k, centValue(value), unitName, unitNamePlural);
         denoms.put(k, d);
         // infrequent insertion, so I don't mind sorting on every insert
         sortedDenoms.add(d);

--- a/src/main/java/org/gestern/gringotts/data/DerbyDAO.java
+++ b/src/main/java/org/gestern/gringotts/data/DerbyDAO.java
@@ -544,7 +544,7 @@ public class DerbyDAO implements DAO {
      * @see org.gestern.gringotts.data.DAO#finalize()
      */
     @Override
-    public void finalize() throws Throwable {
+    protected void finalize() throws Throwable {
         super.finalize();
         shutdown();
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1174 - "Object.finalize()" should remain protected (versus public) when overriding.
squid:S2185- Silly math should not be performed.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1174
https://dev.eclipse.org/sonar/rules/show/squid:S2185

Please let me know if you have any questions.

Faisal Hameed