### PR TITLE
Provide better support for detecting Factions

### DIFF
--- a/src/main/java/org/gestern/gringotts/dependency/Dependency.java
+++ b/src/main/java/org/gestern/gringotts/dependency/Dependency.java
@@ -35,7 +35,7 @@ public enum Dependency {
     private Dependency() {
         factions = FactionsHandler.getFactionsHandler(hookPlugin(
                 "Factions",
-                "com.massivecraft.factions.Factions",
+                "com.massivecraft.factions.TerritoryAccess",
                 "2.12.0"));
         towny = TownyHandler.getTownyHandler(hookPlugin(
                 "Towny",


### PR DESCRIPTION
Changes:
  * Test for factions using the class com.massivecraft.factions.TerritoryAccess. This avoids issues with a fork of factions (SavageFaction) causing Gringotts to fail entirely