### PR TITLE
Fix pay command always sending 0.

### DIFF
--- a/src/main/java/org/gestern/gringotts/commands/MoneyExecutor.java
+++ b/src/main/java/org/gestern/gringotts/commands/MoneyExecutor.java
@@ -45,6 +45,12 @@ public class MoneyExecutor extends GringottsAbstractExecutor {
                 return true;
             }
         } else if ( args.length == 3 && "pay".equals(command)) {
+            try {
+                value = Double.parseDouble(args[1]);
+            } catch (NumberFormatException ignored) {
+                return false;
+            }
+
             // money pay <amount> <player>
             return pay(player, value, args);
         }


### PR DESCRIPTION
The command handler probably actually needs some additional work but this fix will just allow the value to /pay command to now be resolved.

Closes #197
Closes #193